### PR TITLE
Improve README instructions to install from source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Standard cmake workflow:
  - cd *BUILD_DIR* && cmake *SOURCE_DIR*
  - make
  - make install
- 
+
 ## Installing the binary release
   - go to [GitHub release page](https://github.com/ADVRHumanoids/MatLogger2/releases) and download the latest binary
   - sudo dpkg -i matlogger2-X.Y.Z-Linux.deb
-  
+
 The binary release has been tested only with Ubuntu 16.04
 
 ## Linking against MatLogger2
@@ -25,56 +25,56 @@ target_link_libraries(mytarget matlogger2::matlogger2)
  ### Circular-buffer mode
  ```c++
  #include <matlogger2/matlogger2.h>
- 
+
  int main()
  {
     auto logger = XBot::MatLogger2::MakeLogger("/tmp/my_log"); // date-time automatically appended
     logger->set_buffer_mode(XBot::VariableBuffer::Mode::circular_buffer);
-    
+
     for(int i = 0; i < 1e5; i++)
     {
         Eigen::VectorXd vec(10);
         Eigen::MatrixXd mat(6,8);
-        
+
         logger->add("my_vec_var", vec);
         logger->add("my_scalar_var", M_PI);
         logger->add("my_mat_var", mat);
     }
-    
+
  } // destructor flushes to disk
  ```
- 
+
   ### Producer-consumer mode (default)
  ```c++
  #include <matlogger2/matlogger2.h>
  #include <matlogger2/utils/mat_appender.h>
- 
+
  int main()
  {
     auto logger = XBot::MatLogger2::MakeLogger("/tmp/my_log.mat"); // extension provided -> date-time NOT appended
     auto appender = XBot::MatAppender::MakeInstance();
     appender->add_logger(logger);
     appender->start_flush_thread();
-    
+
     for(int i = 0; i < 1e5; i++)
     {
         Eigen::VectorXd vec(10);
         Eigen::MatrixXd mat(6,8);
-        
+
         logger->add("my_vec_var", vec);
         logger->add("my_scalar_var", M_PI);
         logger->add("my_mat_var", mat);
-        
+
         usleep(1000);
     }
-    
+
  }
  ```
- 
+
  ### Custom buffer size and compression
  ```c++
  #include <matlogger2/matlogger2.h>
- 
+
  int main()
  {
     XBot::MatLogger2::Options opt;
@@ -82,28 +82,28 @@ target_link_libraries(mytarget matlogger2::matlogger2)
     opt.enable_compression = true; // enable ZLIB compression
                                    // this can be computationally expensive
     auto logger = XBot::MatLogger2::MakeLogger("/tmp/my_log", opt);
-    
+
     logger->create("my_vec_var", 10); // this pre-allocates the buffer with default buffer size
-    
+
     logger->create("my_mat_var", 6, 8, 1e3); // custom buffer size can be set variable-wise
-    
+
     for(int i = 0; i < 1e5; i++)
     {
         Eigen::VectorXd vec(10);
         Eigen::MatrixXd mat(6,8);
-        
+
         logger->add("my_vec_var", vec);
         logger->add("my_scalar_var", M_PI);
         logger->add("my_mat_var", mat);
-        
+
         usleep(1000);
     }
-    
+
     logger.reset(); // manually destroy the logger in order to flush to disk
-    
- } 
+
+ }
  ```
- 
+
  ### Python bindings
  If [`pybind11`](https://pybind11.readthedocs.io/en/stable/) can be found on your system, python2.7 bindings will be generated and installed. It'll then be possible to log `numpy` arrays and python lists in the same way as the C++ API works with `Eigen3` types and STL classes.
  #### Python API vs C++
@@ -113,10 +113,10 @@ target_link_libraries(mytarget matlogger2::matlogger2)
  ```python
 import matlogger2.matlogger as ml
 
-logger = ml.MatLogger2(file='/tmp/my_log', 
+logger = ml.MatLogger2(file='/tmp/my_log',
                       enable_compression=True,# default value is False
                       default_buffer_size=int(1e5)) # default value is 1e4
-              
+
 logger.setBufferMode(ml.BufferMode.ProducerConsumer) # this is already the default choice
 
 ap = ml.MatAppender()
@@ -129,6 +129,6 @@ logger.add('myvar', [0, 1, 2, 3, 4])
 del(logger) # destroy to force flushing
 
 ```
- 
+
  ## Documentation
  Header files are documented with doxygen! An [**online version**](https://advrhumanoids.github.io/MatLogger2/classXBot_1_1MatLogger2.html) is also available.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ mkdir <BUILD_DIR>
 cd <BUILD_DIR> && cmake <PATH_TO_SOURCE_DIR>
 ```
 
-- Install MatLogger2 (BUILD_DIR)
+- Install MatLogger2
 ```shell
 make install
 ```

--- a/README.md
+++ b/README.md
@@ -2,12 +2,44 @@
 Library for logging of numeric data to HDF5 MAT-files, which is RT-safe and multithreaded.
 
 ## Building MatLogger2 from source
-Standard cmake workflow:
+### Dependencies:
+Installation for Ubuntu Linux:
+```shell
+sudo apt update
+sudo apt install build-essential \
+    cmake \
+    git \
+    libeigen3-dev \
+    libboost-all-dev \
+    libhdf5-serial-dev \
+    pybind11-dev \
+    python3-distutils-extra \
+    lsb-release
+```
+
+### Standard cmake workflow:
  - git clone the repo to *SOURCE_DIR*
  - create a build folder *BUILD_DIR*
  - cd *BUILD_DIR* && cmake *SOURCE_DIR*
  - make
  - make install
+
+### Analytical steps:
+- Clone the repository to a target source directory (SOURCE_DIR):
+```shell
+git clone https://github.com/ADVRHumanoids/MatLogger2.git <SOURCE_DIR>
+```
+
+- Create a build directory (BUILD_DIR) and compile the source code:
+```shell
+mkdir <BUILD_DIR>
+cd <BUILD_DIR> && cmake <PATH_TO_SOURCE_DIR>
+```
+
+- Install MatLogger2 (BUILD_DIR)
+```shell
+make install
+```
 
 ## Installing the binary release
   - go to [GitHub release page](https://github.com/ADVRHumanoids/MatLogger2/releases) and download the latest binary


### PR DESCRIPTION
This PR adds more detailed instructions in the README section on how to install MatLogger2 from source.

More specifically:
- Added a sub-section describing how to install dependencies for Ubuntu Linux.
- Added terminal commands on how to clone, compile and install MatLogger2.